### PR TITLE
added base64-inlining of images

### DIFF
--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -38,6 +38,14 @@ module.exports = function(grunt) {
         $(this).replaceWith('<script>' + grunt.file.read(path.join(path.dirname(filePair.src), script)) + '</script>');
       });
 
+      $('img').each(function () {
+        var src = $(this).attr('src');
+        if (!src) { return; }
+        if (src.match(/^\/\//)) { return; }
+        if (url.parse(src).protocol) { return; }
+        $(this).attr('src', 'data:image/' + src.substr(src.lastIndexOf('.')+1) + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
+      });
+
       grunt.file.write(filePair.dest, $.html());
       grunt.log.writeln('File "' + filePair.dest + '" created.');
     });


### PR DESCRIPTION
I implemented inlining images as base64 data-uris. I must confess I didn't write tests for it right now (but as I saw, I am not the only one with this problem ;) ).

For the moment the mime type is essentially `image/<anything after the last dot>`, which works for png/jpg, but is for sure a bad hack. It would be better to use [node-mime](https://github.com/broofa/node-mime) and implement it as `'data:' + mime.lookup(src) + '...'`. But this would add an additional dependency which might be a bad thing.
