### PR TITLE
Update test to show broken relative URL

### DIFF
--- a/test/expected/default_options
+++ b/test/expected/default_options
@@ -6,7 +6,12 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/themes/ui-lightness/jquery-ui.css">
     <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/themes/ui-lightness/jquery-ui.css">
-    <style>h1 {
+    <style>@font-face {
+  font-family: 'FontAwesome';
+  src: url('fonts/fontawesome-webfont.eot?v=4.0.3');
+}
+
+h1 {
   color: red;
 }
 </style>

--- a/test/fixtures/css/testcss.css
+++ b/test/fixtures/css/testcss.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('../fonts/fontawesome-webfont.eot?v=4.0.3');
+}
+
 h1 {
   color: red;
 }


### PR DESCRIPTION
Relative URLs in the files merged are not remapped, this will break images and fonts referenced (relatively) in included CSS files. 

I guess to fix this would require keeping track of the path of the Html file related to the files to include, and going through those files and replacing all relative URLs.
