### PR TITLE
Added absolute path & script minification support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "cheerio": "~0.10.8"
+    "cheerio": "~0.10.8",
+    "uglifyjs": "~2.3.6"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.4.3",

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
 
     if (options.minify){
       processInput = function(input){
-        return uglify.minify(input, {fromString: true});
+        return uglify.minify(input, {fromString: true}).code;
       };
     }
 

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
 
     if (options.minify){
       processInput = function(input){
-        return uglify.minify(input);
+        return uglify.minify(input, {fromString: true});
       };
     }
 

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -16,18 +16,27 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('smoosher', 'Turn your distribution into something pastable.', function() {
 
+    var options = this.options({
+      jsDir: "",
+      cssDir: ""
+    }); 
+
     this.files.forEach(function(filePair) {
       // Check that the source file exists
       if(filePair.src.length === 0) { return; }
 
       var $ = cheerio.load(grunt.file.read(filePair.src));
 
+      grunt.log.writeln('Reading: ' + path.resolve(filePair.src.toString()));
+
       $('link[rel="stylesheet"]').each(function () {
         var style = $(this).attr('href');
         if(!style) { return; }
         if(style.match(/^\/\//)) { return; }
         if(url.parse(style).protocol) { return; }
-        $(this).replaceWith('<style>' + grunt.file.read(path.join(path.dirname(filePair.src), style)) + '</style>');
+        var filePath = (style.substr(0,1) === "/") ? path.resolve(options.cssDir, style.substr(1)) : path.join(path.dirname(filePair.src), style);
+        grunt.log.writeln(('Including CSS: ').cyan + filePath);
+        $(this).replaceWith('<style>' + grunt.file.read(filePath) + '</style>');
       });
 
       $('script').each(function () {
@@ -35,11 +44,13 @@ module.exports = function(grunt) {
         if(!script) { return; }
         if(script.match(/^\/\//)) { return; }
         if(url.parse(script).protocol) { return; }
-        $(this).replaceWith('<script>' + grunt.file.read(path.join(path.dirname(filePair.src), script)) + '</script>');
+        var filePath = (script.substr(0,1) === "/") ? path.resolve(options.jsDir, script.substr(1)) : path.join(path.dirname(filePair.src), script);
+        grunt.log.writeln(('Including JS: ').cyan + filePath);
+        $(this).replaceWith('<script>' + grunt.file.read(filePath) + '</script>');
       });
 
-      grunt.file.write(filePair.dest, $.html());
-      grunt.log.writeln('File "' + filePair.dest + '" created.');
+      grunt.file.write(path.resolve(filePair.dest), $.html());
+      grunt.log.writeln(('Created ').green + path.resolve(filePair.dest));
     });
 
   });

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
   var cheerio = require('cheerio');
   var path = require('path');
   var url = require('url');
-  var uglify = require('uglifyjs').init(grunt);
+  var uglify = require('uglifyjs');
 
   grunt.registerMultiTask('smoosher', 'Turn your distribution into something pastable.', function() {
 


### PR DESCRIPTION
Task now can take 3 options:

```
{
    jsDir: "../../js/",
    cssDir: "../../css/",
    minify: true
}
```

The first two are directories are where the js and css files are located, relative to the uncompiled html. This helps when paths are listed absolutely.

The third is a boolean to run the scripts through uglifyjs before writing inline.
