### PR TITLE
Support passing custom css / js tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ In your project's Gruntfile, add a section named `smoosher` to the data object p
 ```js
 grunt.initConfig({
   smoosher: {
+    options: {
+      jsTags: { // optional
+        start: '<script type="text/javascript">', // default: <script>
+        end: '</script>'                          // default: </script>
+      },
+    },
     all: {
       files: {
         'dest-index.html': 'source-index.html',
@@ -38,7 +44,28 @@ grunt.initConfig({
 
 ### Options
 
-None.
+#### cssTags
+
+Defaults to 
+
+```js
+{
+  start: '<style>',
+  end: '</style>'
+}
+```
+
+#### jsTags
+
+Defaults to 
+
+```js
+{
+  start: '<script>',
+  end: '</script>'
+}
+```
+
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
         if(url.parse(script).protocol) { return; }
         var filePath = (script.substr(0,1) === "/") ? path.resolve(options.jsDir, script.substr(1)) : path.join(path.dirname(filePair.src), script);
         grunt.log.writeln(('Including JS: ').cyan + filePath);
-        $(this).replaceWith(options.jsTags.start + processInput(grunt.file.read(filePath)) + options.cssTags.end);
+        $(this).replaceWith(options.jsTags.start + processInput(grunt.file.read(filePath)) + options.jsTags.end);
       });
 
       grunt.file.write(path.resolve(filePair.dest), $.html());

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -22,6 +22,17 @@ module.exports = function(grunt) {
       cssDir: "",
       minify: false
     }); 
+
+    options.cssTags = this.options().cssTags || {
+      start: '<style>',
+      end: '</style>'
+    };
+
+    options.jsTags = this.options().jsTags || {
+      start: '<script>',
+      end: '</script>'
+    };
+
     var processInput = function(i){return i;};
 
     if (options.minify){
@@ -45,7 +56,7 @@ module.exports = function(grunt) {
         if(url.parse(style).protocol) { return; }
         var filePath = (style.substr(0,1) === "/") ? path.resolve(options.cssDir, style.substr(1)) : path.join(path.dirname(filePair.src), style);
         grunt.log.writeln(('Including CSS: ').cyan + filePath);
-        $(this).replaceWith('<style>' + processInput(grunt.file.read(filePath)) + '</style>');
+        $(this).replaceWith(options.cssTags.start + processInput(grunt.file.read(filePath)) + options.cssTags.end);
       });
 
       $('script').each(function () {
@@ -55,7 +66,7 @@ module.exports = function(grunt) {
         if(url.parse(script).protocol) { return; }
         var filePath = (script.substr(0,1) === "/") ? path.resolve(options.jsDir, script.substr(1)) : path.join(path.dirname(filePair.src), script);
         grunt.log.writeln(('Including JS: ').cyan + filePath);
-        $(this).replaceWith('<script>' + processInput(grunt.file.read(filePath)) + '</script>');
+        $(this).replaceWith(options.jsTags.start + processInput(grunt.file.read(filePath)) + options.cssTags.end);
       });
 
       grunt.file.write(path.resolve(filePair.dest), $.html());


### PR DESCRIPTION
I need to output

``` html
<p:style>...</p:style>
```

instead of the usual

``` html
<style></style>
```

This pull request adds two options, show here with their defaults:

``` js
cssTags: {
  start: '<style>',
  end: '</style>' 
},
jsTags: {
  start: '<script>',
  end: '</script>'
}
```
