### PR TITLE
Cope with SVG images

### DIFF
--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -92,15 +92,12 @@ module.exports = function(grunt) {
 
       $('img').each(function () {
         var src = $(this).attr('src');
+        var extension = src.substr(src.lastIndexOf('.')+1);
         if (!src) { return; }
         if (src.match(/^\/\//)) { return; }
         if (url.parse(src).protocol) { return; }
-        var imgStr = src.substr(src.lastIndexOf('.')+1);
-        if (imgStr === 'svg') {
-          imgStr += '+xml';
-        }
-        grunt.log.writeln(imgStr);
-        $(this).attr('src', 'data:image/' + imgStr + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
+        if (extension === 'svg') { extension += '+xml'; }
+        $(this).attr('src', 'data:image/' + extension + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
       });
 
       grunt.file.write(path.resolve(filePair.dest), $.html());

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -95,7 +95,12 @@ module.exports = function(grunt) {
         if (!src) { return; }
         if (src.match(/^\/\//)) { return; }
         if (url.parse(src).protocol) { return; }
-        $(this).attr('src', 'data:image/' + src.substr(src.lastIndexOf('.')+1) + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
+        var imgStr = src.substr(src.lastIndexOf('.')+1);
+        if (imgStr === 'svg') {
+          imgStr += '+xml';
+        }
+        grunt.log(imgStr);
+        $(this).attr('src', 'data:image/' + imgStr + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
       });
 
       grunt.file.write(path.resolve(filePair.dest), $.html());

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
         if (imgStr === 'svg') {
           imgStr += '+xml';
         }
-        grunt.log(imgStr);
+        grunt.log.writeln(imgStr);
         $(this).attr('src', 'data:image/' + imgStr + ';base64,' + new Buffer(grunt.file.read(path.join(path.dirname(filePair.src), src), { encoding: null })).toString('base64'));
       });
 


### PR DESCRIPTION
When using SVG images, the base64 declaration requires 'svg+xml'
I haven't looked into this issue too deeply I'm afraid, I just added a coping mechanism for this particular scenario.
