### PR TITLE
uglifyjs has been yanked from npmjs in favour of uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "cheerio": "~0.10.8",
-    "uglifyjs": "~2.3.6"
+    "uglify-js": "~2.3.6"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.4.3",

--- a/tasks/html_smoosher.js
+++ b/tasks/html_smoosher.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
   var cheerio = require('cheerio');
   var path = require('path');
   var url = require('url');
-  var uglify = require('uglifyjs');
+  var uglify = require('uglify-js');
 
   grunt.registerMultiTask('smoosher', 'Turn your distribution into something pastable.', function() {
 


### PR DESCRIPTION
uglifyjs got yanked this morning, causing `npm install grunt-html-smoosher` to fail.

See https://twitter.com/ForbesLindesay/status/564750368865665024
