### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "cheerio": "~0.10.8",
-    "uglifyjs": "~2.3.6"
+    "uglify-js": "~2.3.6"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.4.3",


### PR DESCRIPTION
It looks like `uglify-js` (with a dash) is the preferred NPM package for uglify, at least to access older versions. This package installs again now.
