### PR TITLE
chore: drop support for Node.js 8 and 10

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 12"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Drop Node.js 8 and 10 and add Node.js 16.

BREAKING CHANGE: Drop support for Node.js 8 and 10.