### PR TITLE
fix: remove grunt-contrib-clean

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,10 +11,6 @@
 module.exports = function (grunt) {
   // Project configuration.
   grunt.initConfig({
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      tests: ['tmp']
-    },
 
     // Configuration to be run (and then tested).
     smoosher: {
@@ -41,9 +37,14 @@ module.exports = function (grunt) {
   // Actually load this plugin's task(s).
   grunt.loadTasks('tasks');
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-clean');
+  // This plugin provides a necessary task.
   grunt.loadNpmTasks('grunt-run');
+
+  grunt.registerTask('clean', 'Clean tmp directory', function () {
+    if (grunt.file.isDir('./tmp')) {
+      grunt.file.delete('./tmp');
+    }
+  });
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "3.0.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",
-        "uglify-js": "^3.15.3"
+        "uglify-js": "^3.15.4"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
-        "grunt": "^1.4.1",
-        "grunt-contrib-clean": "^2.0.0",
+        "grunt": "^1.5.2",
         "grunt-run": "^0.8.1",
         "semantic-release": "^19.0.2",
         "semistandard": "^16.0.1"
@@ -46,9 +45,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -119,6 +118,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -438,9 +447,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.2.tgz",
-      "integrity": "sha512-wIbfhOeuxlYzMTjtSAa2xgr54n7ZuPAS2gadyTWBpUt2PNAPgla7A6XxCXJnaKPgfVF0iFfSk3B+KlVKk6ByVg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+      "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^18.0.0",
@@ -781,14 +790,15 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -798,14 +808,15 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -830,15 +841,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/at-least-node": {
@@ -993,15 +995,15 @@
       }
     },
     "node_modules/cheerio-select": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
-      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
       "dependencies": {
-        "css-select": "^4.1.3",
-        "css-what": "^5.0.1",
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
         "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.7.0"
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -1017,9 +1019,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
@@ -1028,17 +1030,7 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "1.4.0"
-      }
-    },
-    "node_modules/cli-table3/node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cliui": {
@@ -1240,13 +1232,13 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
-        "domhandler": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       },
@@ -1255,9 +1247,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "engines": {
         "node": ">= 6"
       },
@@ -1426,9 +1418,9 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -1439,9 +1431,9 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
@@ -1547,9 +1539,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.4.tgz",
+      "integrity": "sha512-flV8e5g9/xulChMG48Fygk1ptpo4lQRJ0eJYtxJFgi7pklLx7EFcOJ34jnvr8pbWlaFN/AT1cZpe0hiFel9Hqg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -1558,15 +1550,15 @@
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
@@ -1578,6 +1570,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
       }
     },
     "node_modules/es-to-primitive": {
@@ -1863,9 +1864,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -1873,14 +1874,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "engines": {
         "node": ">=4"
@@ -1908,6 +1909,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
@@ -2748,15 +2761,15 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/grunt": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
-      "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.2.tgz",
+      "integrity": "sha512-XCtfaIu72OyDqK24MjWiGC9SwlkuhkS1mrULr1xzuJ2XqAFhP3ZAchZGHJeSCY6mkaOXU4F7SbmmCF7xIVoC9w==",
       "dev": true,
       "dependencies": {
         "dateformat": "~3.0.3",
@@ -2764,7 +2777,7 @@
         "exit": "~0.1.2",
         "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.2",
+        "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
@@ -2812,34 +2825,6 @@
       },
       "bin": {
         "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/grunt-contrib-clean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
-      "integrity": "sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==",
-      "dev": true,
-      "dependencies": {
-        "async": "^2.6.1",
-        "rimraf": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "grunt": ">=0.4.5"
-      }
-    },
-    "node_modules/grunt-contrib-clean/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/grunt-known-options": {
@@ -3373,9 +3358,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3464,10 +3449,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3704,12 +3692,12 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
-      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz",
+      "integrity": "sha512-HDAyJ4MNQBboGpUnHAVUNJs6X0lh058s6FuixsFGP7MgJYpD6Vasd6nzSG5iIfXu1zAYlHJ/zsOKNlrenTUBnw==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
+        "array-includes": "^3.1.4",
         "object.assign": "^4.1.2"
       },
       "engines": {
@@ -3930,9 +3918,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -4026,13 +4014,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -4214,14 +4202,15 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
-      "integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+      "integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/ci-detect",
         "@npmcli/config",
+        "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/run-script",
@@ -4293,9 +4282,10 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.3",
+        "@npmcli/arborist": "^5.0.4",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.0.1",
+        "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.2",
         "@npmcli/package-json": "^1.0.1",
         "@npmcli/run-script": "^3.0.1",
@@ -4303,7 +4293,7 @@
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
-        "cacache": "^16.0.2",
+        "cacache": "^16.0.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
@@ -4314,7 +4304,7 @@
         "graceful-fs": "^4.2.9",
         "hosted-git-info": "^5.0.0",
         "ini": "^2.0.0",
-        "init-package-json": "^3.0.1",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
         "libnpmaccess": "^6.0.2",
@@ -4328,7 +4318,7 @@
         "libnpmsearch": "^5.0.2",
         "libnpmteam": "^4.0.2",
         "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.0.6",
+        "make-fetch-happen": "^10.1.1",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -4336,18 +4326,18 @@
         "ms": "^2.1.2",
         "node-gyp": "^9.0.0",
         "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
+        "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^4.0.0",
         "npm-package-arg": "^9.0.1",
         "npm-pick-manifest": "^7.0.0",
         "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.0.1",
+        "npm-registry-fetch": "^13.1.0",
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.1",
         "opener": "^1.5.2",
         "pacote": "^13.0.5",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
         "read-package-json": "^5.0.0",
@@ -4360,7 +4350,7 @@
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
+        "validate-npm-package-name": "^4.0.0",
         "which": "^2.0.2",
         "write-file-atomic": "^4.0.1"
       },
@@ -4397,7 +4387,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4441,7 +4431,7 @@
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
@@ -4485,16 +4475,16 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "1.1.0",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promisify": "^1.0.1",
+        "@gar/promisify": "^1.1.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
@@ -4806,24 +4796,27 @@
       }
     },
     "node_modules/npm/node_modules/builtins": {
-      "version": "1.0.3",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.0.2",
+      "version": "16.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^1.0.0",
+        "@npmcli/fs": "^2.1.0",
         "@npmcli/move-file": "^1.1.2",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
         "glob": "^7.2.0",
         "infer-owner": "^1.0.4",
-        "lru-cache": "^7.5.1",
+        "lru-cache": "^7.7.1",
         "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
@@ -4837,7 +4830,7 @@
         "unique-filename": "^1.1.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
@@ -5004,7 +4997,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.3",
+      "version": "4.3.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5140,7 +5133,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5155,7 +5148,7 @@
         "wide-align": "^1.1.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/glob": {
@@ -5340,21 +5333,21 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.0.0",
+        "npm-package-arg": "^9.0.1",
         "promzard": "^0.3.0",
         "read": "^1.0.7",
         "read-package-json": "^5.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^3.0.0"
+        "validate-npm-package-name": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/ip": {
@@ -5448,7 +5441,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "4.0.1",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -5465,7 +5458,7 @@
         "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
@@ -5484,7 +5477,7 @@
         "tar": "^6.1.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
@@ -5507,7 +5500,7 @@
         "walk-up-path": "^1.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
@@ -5519,7 +5512,7 @@
         "@npmcli/arborist": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
@@ -5532,7 +5525,7 @@
         "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
@@ -5545,7 +5538,7 @@
         "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
@@ -5559,7 +5552,7 @@
         "pacote": "^13.0.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
@@ -5575,7 +5568,7 @@
         "ssri": "^8.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
@@ -5587,7 +5580,7 @@
         "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
@@ -5600,7 +5593,7 @@
         "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
@@ -5617,11 +5610,11 @@
         "stringify-package": "^1.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.5.1",
+      "version": "7.7.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5630,18 +5623,18 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.0.6",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.0.0",
+        "cacache": "^16.0.2",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
-        "lru-cache": "^7.5.1",
+        "lru-cache": "^7.7.1",
         "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
         "minipass-fetch": "^2.0.3",
@@ -5653,7 +5646,7 @@
         "ssri": "^8.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
@@ -5693,7 +5686,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.0.3",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5703,7 +5696,7 @@
         "minizlib": "^2.1.2"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
@@ -5870,7 +5863,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "2.1.5",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5878,7 +5871,7 @@
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
@@ -5909,17 +5902,17 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.0.1",
+      "version": "9.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^5.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^3.0.0"
+        "validate-npm-package-name": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
@@ -5969,21 +5962,21 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.0.1",
+      "version": "13.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "make-fetch-happen": "^10.0.3",
+        "make-fetch-happen": "^10.0.6",
         "minipass": "^3.1.6",
-        "minipass-fetch": "^2.0.1",
+        "minipass-fetch": "^2.0.3",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
-        "npm-package-arg": "^9.0.0",
+        "npm-package-arg": "^9.0.1",
         "proc-log": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
@@ -6076,17 +6069,17 @@
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "json-parse-even-better-errors": "^2.3.1",
         "just-diff": "^5.0.1",
-        "just-diff-apply": "^4.0.1"
+        "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/path-is-absolute": {
@@ -6099,12 +6092,12 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -6528,12 +6521,15 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "builtins": "^1.0.3"
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
@@ -7374,9 +7370,9 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.2.tgz",
+      "integrity": "sha512-Ynz8fTQW5/1elh+jWU2EDDzeoNbD0OQ0R+D1VJU5ATOkUaro4A9YEkdN2ODQl/8UQFPPpZNw91fOcLFamM7Pww==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7619,9 +7615,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8449,9 +8445,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -8771,9 +8767,9 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -8832,6 +8828,13 @@
           }
         }
       }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -9097,9 +9100,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.2.tgz",
-      "integrity": "sha512-wIbfhOeuxlYzMTjtSAa2xgr54n7ZuPAS2gadyTWBpUt2PNAPgla7A6XxCXJnaKPgfVF0iFfSk3B+KlVKk6ByVg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+      "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.0.0",
@@ -9366,25 +9369,27 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "arrify": {
@@ -9398,15 +9403,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -9524,15 +9520,15 @@
       }
     },
     "cheerio-select": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
-      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
       "requires": {
-        "css-select": "^4.1.3",
-        "css-what": "^5.0.1",
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
         "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.7.0"
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
       }
     },
     "clean-stack": {
@@ -9542,22 +9538,13 @@
       "dev": true
     },
     "cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0",
+        "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "cliui": {
@@ -9721,21 +9708,21 @@
       "dev": true
     },
     "css-select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
-        "domhandler": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       }
     },
     "css-what": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -9855,9 +9842,9 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -9865,9 +9852,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "4.3.1",
@@ -9946,9 +9933,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.4.tgz",
+      "integrity": "sha512-flV8e5g9/xulChMG48Fygk1ptpo4lQRJ0eJYtxJFgi7pklLx7EFcOJ34jnvr8pbWlaFN/AT1cZpe0hiFel9Hqg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -9957,20 +9944,29 @@
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
         "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -10211,9 +10207,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -10221,14 +10217,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.2",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.12.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "debug": {
@@ -10247,6 +10243,15 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -10840,15 +10845,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "grunt": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
-      "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.2.tgz",
+      "integrity": "sha512-XCtfaIu72OyDqK24MjWiGC9SwlkuhkS1mrULr1xzuJ2XqAFhP3ZAchZGHJeSCY6mkaOXU4F7SbmmCF7xIVoC9w==",
       "dev": true,
       "requires": {
         "dateformat": "~3.0.3",
@@ -10856,7 +10861,7 @@
         "exit": "~0.1.2",
         "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.2",
+        "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
@@ -10889,27 +10894,6 @@
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
-          }
-        }
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
-      "integrity": "sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.1",
-        "rimraf": "^2.6.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
           }
         }
       }
@@ -11290,9 +11274,9 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -11351,10 +11335,13 @@
       }
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-stream": {
       "version": "2.0.1",
@@ -11532,12 +11519,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
-      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz",
+      "integrity": "sha512-HDAyJ4MNQBboGpUnHAVUNJs6X0lh058s6FuixsFGP7MgJYpD6Vasd6nzSG5iIfXu1zAYlHJ/zsOKNlrenTUBnw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
+        "array-includes": "^3.1.4",
         "object.assign": "^4.1.2"
       }
     },
@@ -11720,9 +11707,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
       "dev": true
     },
     "marked-terminal": {
@@ -11787,13 +11774,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -11922,15 +11909,16 @@
       "dev": true
     },
     "npm": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
-      "integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+      "integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.3",
+        "@npmcli/arborist": "^5.0.4",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.0.1",
+        "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.2",
         "@npmcli/package-json": "^1.0.1",
         "@npmcli/run-script": "^3.0.1",
@@ -11938,7 +11926,7 @@
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
-        "cacache": "^16.0.2",
+        "cacache": "^16.0.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
@@ -11949,7 +11937,7 @@
         "graceful-fs": "^4.2.9",
         "hosted-git-info": "^5.0.0",
         "ini": "^2.0.0",
-        "init-package-json": "^3.0.1",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
         "libnpmaccess": "^6.0.2",
@@ -11963,7 +11951,7 @@
         "libnpmsearch": "^5.0.2",
         "libnpmteam": "^4.0.2",
         "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.0.6",
+        "make-fetch-happen": "^10.1.1",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -11971,18 +11959,18 @@
         "ms": "^2.1.2",
         "node-gyp": "^9.0.0",
         "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
+        "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^4.0.0",
         "npm-package-arg": "^9.0.1",
         "npm-pick-manifest": "^7.0.0",
         "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.0.1",
+        "npm-registry-fetch": "^13.1.0",
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.1",
         "opener": "^1.5.2",
         "pacote": "^13.0.5",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
         "read-package-json": "^5.0.0",
@@ -11995,7 +11983,7 @@
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
+        "validate-npm-package-name": "^4.0.0",
         "which": "^2.0.2",
         "write-file-atomic": "^4.0.1"
       },
@@ -12011,7 +11999,7 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "5.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12080,11 +12068,11 @@
           }
         },
         "@npmcli/fs": {
-          "version": "1.1.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@gar/promisify": "^1.0.1",
+            "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
           }
         },
@@ -12316,22 +12304,25 @@
           }
         },
         "builtins": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "cacache": {
-          "version": "16.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^1.0.0",
+            "semver": "^7.0.0"
+          }
+        },
+        "cacache": {
+          "version": "16.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^2.1.0",
             "@npmcli/move-file": "^1.1.2",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
             "glob": "^7.2.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^7.5.1",
+            "lru-cache": "^7.7.1",
             "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
@@ -12452,7 +12443,7 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.3",
+          "version": "4.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12551,7 +12542,7 @@
           "dev": true
         },
         "gauge": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12693,17 +12684,17 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^9.0.0",
+            "npm-package-arg": "^9.0.1",
             "promzard": "^0.3.0",
             "read": "^1.0.7",
             "read-package-json": "^5.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^3.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "ip": {
@@ -12768,7 +12759,7 @@
           "dev": true
         },
         "just-diff-apply": {
-          "version": "4.0.1",
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
@@ -12896,22 +12887,22 @@
           }
         },
         "lru-cache": {
-          "version": "7.5.1",
+          "version": "7.7.1",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.0.6",
+          "version": "10.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
-            "cacache": "^16.0.0",
+            "cacache": "^16.0.2",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "lru-cache": "^7.5.1",
+            "lru-cache": "^7.7.1",
             "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-fetch": "^2.0.3",
@@ -12948,7 +12939,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "2.0.3",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13067,7 +13058,7 @@
           }
         },
         "npm-audit-report": {
-          "version": "2.1.5",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13096,13 +13087,13 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "9.0.1",
+          "version": "9.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^5.0.0",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^3.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "npm-packlist": {
@@ -13137,16 +13128,16 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "13.0.1",
+          "version": "13.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^10.0.3",
+            "make-fetch-happen": "^10.0.6",
             "minipass": "^3.1.6",
-            "minipass-fetch": "^2.0.1",
+            "minipass-fetch": "^2.0.3",
             "minipass-json-stream": "^1.0.1",
             "minizlib": "^2.1.2",
-            "npm-package-arg": "^9.0.0",
+            "npm-package-arg": "^9.0.1",
             "proc-log": "^2.0.0"
           }
         },
@@ -13216,13 +13207,13 @@
           }
         },
         "parse-conflict-json": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1",
             "just-diff": "^5.0.1",
-            "just-diff-apply": "^4.0.1"
+            "just-diff-apply": "^5.2.0"
           }
         },
         "path-is-absolute": {
@@ -13231,7 +13222,7 @@
           "dev": true
         },
         "proc-log": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -13536,11 +13527,11 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
@@ -14172,9 +14163,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.2.tgz",
+      "integrity": "sha512-Ynz8fTQW5/1elh+jWU2EDDzeoNbD0OQ0R+D1VJU5ATOkUaro4A9YEkdN2ODQl/8UQFPPpZNw91fOcLFamM7Pww==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -14331,9 +14322,9 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -14976,9 +14967,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg=="
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,12 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.10",
-    "uglify-js": "^3.15.3"
+    "uglify-js": "^3.15.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "grunt": "^1.4.1",
-    "grunt-contrib-clean": "^2.0.0",
+    "grunt": "^1.5.2",
     "grunt-run": "^0.8.1",
     "semantic-release": "^19.0.2",
     "semistandard": "^16.0.1"


### PR DESCRIPTION
grunt-contrib-clean hasn't had a version published in years. It is
trivial to use `grunt.delete.file` in our situation instead. This
removes an `npm audit`/GitHub interface warning for development.